### PR TITLE
aixpert can save the current cunfiguration to a file. If that file pa…

### DIFF
--- a/plugins/modules/aixpert.py
+++ b/plugins/modules/aixpert.py
@@ -121,6 +121,7 @@ stderr:
 
 from ansible.module_utils.basic import AnsibleModule
 import os
+import re
 
 
 def check_settings(module):
@@ -207,6 +208,14 @@ def apply_settings(module, mode):
     if rc != 0:
         msg = "Unable to apply or save aixpert settings. Command in failure '%s' " % cmd
         module.fail_json(msg=msg, rc=rc, stdout=stdout, stderr=stderr)
+
+    # The aixpert can fail if file path is invalid  but still return 0"
+    # setFilePosition():fopen(/home/test123321/norm.xml)  failed, errno=2
+    pattern = "errno=2"
+    found = re.search(pattern, stderr)
+    if found:
+        msg = "Unable to access the file from command: '%s' " % cmd
+        module.fail_json(msg=msg, rc=1, stdout=stdout, stderr=stderr)
 
     changed = True
     msg = "aixpert settings applied/saved successfully."


### PR DESCRIPTION
aixpert can save the current rules configuration to a file.
If that file path is invalid (folder does not exist), the module does not return an error.
This can mislead the user to believe the rules were changed, but they were not.